### PR TITLE
Travis-CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,6 @@ before_script:
   # configure apache virtual hosts
   - sudo cp -f build/travis-ci-apache /etc/apache2/sites-available/default
   - sudo sed -e "s?%TRAVIS_BUILD_DIR%?$(pwd)?g" --in-place /etc/apache2/sites-available/default
-  - sudo service apache2 restart
 
   # create a new database
   - mysql -e 'CREATE DATABASE starterkit'
@@ -56,6 +55,10 @@ before_script:
 script:
   # build the distribution using Drush make.
   - drush make --prepare-install make/ucsf_installprofile.make webroot
+
+  # restart apache
+  - sudo service apache2 restart
+  - until netstat -an 2>/dev/null | grep '80.*LISTEN'; do true; done
 
   - cd ${TRAVIS_BUILD_DIR}/webroot
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,9 @@ install:
   # install drush globally
   - composer global require drush/drush:6.*
 
+  #  install behat and co
+  - composer install -d tests/behat
+
 before_script:
   # enable php-fpm
   - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
@@ -42,6 +45,14 @@ before_script:
   # create a new database
   - mysql -e 'CREATE DATABASE starterkit'
 
+  # start Selenium as hub server for Behat tests
+  - java -jar ${TRAVIS_BUILD_DIR}/tests/behat/bin/selenium-server.jar -role hub > /dev/null &
+  - until netstat -an 2>/dev/null | grep '4444.*LISTEN'; do true; done
+
+  # start Phantom for headless Behat tests
+  - phantomjs --webdriver=8080 --webdriver-selenium-grid-hub=http://127.0.0.1:4444 --ignore-ssl-errors=true > /dev/null &
+  - until netstat -an 2>/dev/null | grep '8080.*LISTEN'; do true; done
+
 script:
   # build the distribution using Drush make.
   - drush make --prepare-install make/ucsf_installprofile.make webroot
@@ -51,5 +62,5 @@ script:
   # create new site, stubbing sendmail path with true to prevent delivery errors and manually resolving drush path
   - php -d sendmail_path=`which true` ~/.composer/vendor/bin/drush.php --yes site-install ucsf_installprofile --db-url=mysql://root:@127.0.0.1/starterkit
 
-
-
+  # run behat tests
+  - ${TRAVIS_BUILD_DIR}/tests/behat/bin/behat -p headless

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: php
 
 php:
+  - 5.3
   - 5.4
   - 5.5
 
 mysql:
-  database: starterkit
   username: root
   encoding: utf8
 
@@ -16,6 +16,9 @@ install:
   # install php packages required for running a web server from drush on php 5.4
   - sudo apt-get install -y --force-yes php5-cgi php5-mysql
 
+  # install apache
+  - sudo apt-get install apache2 libapache2-mod-fastcgi
+
   # add composer's global bin directory to the path
   # see: https://github.com/drush-ops/drush#install---composer
   - sed -i '1i export PATH="$HOME/.composer/vendor/bin:$PATH"' $HOME/.bashrc
@@ -24,11 +27,22 @@ install:
   # install drush globally
   - composer global require drush/drush:6.*
 
-script:
+before_script:
+  # enable php-fpm
+  - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
+  - sudo a2enmod rewrite actions fastcgi alias
+  - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
+
+  # configure apache virtual hosts
+  - sudo cp -f build/travis-ci-apache /etc/apache2/sites-available/default
+  - sudo sed -e "s?%TRAVIS_BUILD_DIR%?$(pwd)?g" --in-place /etc/apache2/sites-available/default
+  - sudo service apache2 restart
 
   # create a new database
   - mysql -e 'CREATE DATABASE starterkit'
 
+script:
   # build the distribution using Drush make.
   - drush make --prepare-install make/ucsf_installprofile.make webroot
 
@@ -37,7 +51,5 @@ script:
   # create new site, stubbing sendmail path with true to prevent delivery errors and manually resolving drush path
   - php -d sendmail_path=`which true` ~/.composer/vendor/bin/drush.php --yes site-install ucsf_installprofile --db-url=mysql://root:@127.0.0.1/starterkit
 
-  # start a web server on port 8080, run in the background; wait for initialization to complete.
-  - drush runserver 127.0.0.1:8888 &
-  - until netstat -an 2>/dev/null | grep '8888.*LISTEN'; do true; done
+
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ script:
   - cd webroot
 
   # create new site, stubbing sendmail path with true to prevent delivery errors and manually resolving drush path
-  - php -d sendmail_path=`which true` ~/.composer/vendor/bin/drush.php --yes site-install --profile=ucsf_installprofile --no-server --db-url=mysql://root:@127.0.0.1/starterkit
+  - php -d sendmail_path=`which true` ~/.composer/vendor/bin/drush.php --yes site-install ucsf_installprofile --db-url=mysql://root:@127.0.0.1/starterkit
 
   # start a web server on port 8080, run in the background; wait for initialization to complete.
   - drush runserver 127.0.0.1:8888 &

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,10 +57,10 @@ script:
   # build the distribution using Drush make.
   - drush make --prepare-install make/ucsf_installprofile.make webroot
 
-  - cd webroot
+  - cd ${TRAVIS_BUILD_DIR}/webroot
 
   # create new site, stubbing sendmail path with true to prevent delivery errors and manually resolving drush path
   - php -d sendmail_path=`which true` ~/.composer/vendor/bin/drush.php --yes site-install ucsf_installprofile --db-url=mysql://root:@127.0.0.1/starterkit
 
   # run behat tests
-  - ${TRAVIS_BUILD_DIR}/tests/behat/bin/behat -p headless
+  - ${TRAVIS_BUILD_DIR}/tests/behat/bin/behat -c ${TRAVIS_BUILD_DIR}/tests/behat/behat.yml -p headless

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
   - mysql -e 'CREATE DATABASE starterkit'
 
   # build the distribution using Drush make.
-  - drush make --prepare-install make/ucsf_installprofile-dev.make webroot
+  - drush make --prepare-install make/ucsf_installprofile.make webroot
 
   - cd webroot
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+language: php
+
+php:
+  - 5.4
+  - 5.5
+
+mysql:
+  database: starterkit
+  username: root
+  encoding: utf8
+
+before_install:
+  - sudo apt-get update > /dev/null
+
+install:
+  # install php packages required for running a web server from drush on php 5.4
+  - sudo apt-get install -y --force-yes php5-cgi php5-mysql
+
+  # add composer's global bin directory to the path
+  # see: https://github.com/drush-ops/drush#install---composer
+  - sed -i '1i export PATH="$HOME/.composer/vendor/bin:$PATH"' $HOME/.bashrc
+  - source $HOME/.bashrc
+
+  # install drush globally
+  - composer global require drush/drush:6.*
+
+script:
+
+  # create a new database
+  - mysql -e 'CREATE DATABASE starterkit'
+
+  # build the distribution using Drush make.
+  - drush make --prepare-install make/ucsf_installprofile-dev.make webroot
+
+  - cd webroot
+
+  # create new site, stubbing sendmail path with true to prevent delivery errors and manually resolving drush path
+  - php -d sendmail_path=`which true` ~/.composer/vendor/bin/drush.php --yes site-install --profile=ucsf_installprofile --no-server --db-url=mysql://root:@127.0.0.1/starterkit
+
+  # start a web server on port 8080, run in the background; wait for initialization to complete.
+  - drush runserver 127.0.0.1:8888 &
+  - until netstat -an 2>/dev/null | grep '8888.*LISTEN'; do true; done
+

--- a/build/travis-ci-apache
+++ b/build/travis-ci-apache
@@ -1,0 +1,20 @@
+<VirtualHost *:80>
+
+  DocumentRoot %TRAVIS_BUILD_DIR%
+
+  <Directory "%TRAVIS_BUILD_DIR%">
+    Options FollowSymLinks MultiViews ExecCGI
+    AllowOverride All
+    Order deny,allow
+    Allow from all
+  </Directory>
+
+  # Wire up Apache to use Travis CI's php-fpm.
+  <IfModule mod_fastcgi.c>
+    AddHandler php5-fcgi .php
+    Action php5-fcgi /php5-fcgi
+    Alias /php5-fcgi /usr/lib/cgi-bin/php5-fcgi
+    FastCgiExternalServer /usr/lib/cgi-bin/php5-fcgi -host 127.0.0.1:9000 -pass-header Authorization
+  </IfModule>
+
+</VirtualHost>

--- a/build/travis-ci-apache
+++ b/build/travis-ci-apache
@@ -1,6 +1,6 @@
 <VirtualHost *:80>
 
-  DocumentRoot /webroot
+  DocumentRoot %TRAVIS_BUILD_DIR%/webroot
 
   <Directory "%TRAVIS_BUILD_DIR%/webroot">
     Options FollowSymLinks MultiViews ExecCGI

--- a/build/travis-ci-apache
+++ b/build/travis-ci-apache
@@ -1,8 +1,8 @@
 <VirtualHost *:80>
 
-  DocumentRoot %TRAVIS_BUILD_DIR%
+  DocumentRoot /webroot
 
-  <Directory "%TRAVIS_BUILD_DIR%">
+  <Directory "%TRAVIS_BUILD_DIR%/webroot">
     Options FollowSymLinks MultiViews ExecCGI
     AllowOverride All
     Order deny,allow

--- a/tests/behat/README.md
+++ b/tests/behat/README.md
@@ -1,6 +1,8 @@
 # How to run Behat tests
 
-The assumption is that you are doing this on a recent Linux distro.
+The assumption is that you are the site is being served up on `localhost`, port `80`.
+
+These instructions were compiled on a recent Linux (Fedora) environment, Mac users should be able to follow along without problems.
 
 ## Prerequisites
 
@@ -62,7 +64,8 @@ At the very least, you must have PHP 5.3.5+ and the Firefox browser installed in
 
    Make sure your `php-xml` PHP extension is installed or up-to-date.
 
-    ```
+    ```bash
+    # Fedora/RHEL/CentOS
     sudo yum install php-xml
     ```
 
@@ -70,7 +73,8 @@ At the very least, you must have PHP 5.3.5+ and the Firefox browser installed in
 
    Make sure you have installed the `php-mbstring` PHP extension.
 
-    ```
+    ```bash
+    # Fedora/RHEL/CentOS
     sudo yum install php-mbstring
     ```
 
@@ -78,6 +82,6 @@ At the very least, you must have PHP 5.3.5+ and the Firefox browser installed in
 
    Behat is probably not picking up the type of terminal you're using.  Forcing it to run in ANSI mode will probably fix it.
 
-    ```
+    ```bash
     bin/behat --ansi
     ```

--- a/tests/behat/README.md
+++ b/tests/behat/README.md
@@ -1,6 +1,9 @@
 # How to run Behat tests
 
-The assumption is that you are doing this on a recent Linux distro.
+The assumption is that you are the site is being served up on `localhost`, port `80`.
+
+These instructions were compiled on a recent Linux (Fedora) environment; Mac users should be able to follow along without problems.
+Windows-users may need to further investigate the internet for their OS-specific setup instructions.
 
 ## Prerequisites
 
@@ -62,7 +65,8 @@ At the very least, you must have PHP 5.3.5+ and the Firefox browser installed in
 
    Make sure your `php-xml` PHP extension is installed or up-to-date.
 
-    ```
+    ```bash
+    # Fedora/RHEL/CentOS
     sudo yum install php-xml
     ```
 
@@ -70,7 +74,8 @@ At the very least, you must have PHP 5.3.5+ and the Firefox browser installed in
 
    Make sure you have installed the `php-mbstring` PHP extension.
 
-    ```
+    ```bash
+    # Fedora/RHEL/CentOS
     sudo yum install php-mbstring
     ```
 
@@ -78,6 +83,6 @@ At the very least, you must have PHP 5.3.5+ and the Firefox browser installed in
 
    Behat is probably not picking up the type of terminal you're using.  Forcing it to run in ANSI mode will probably fix it.
 
-    ```
+    ```bash
     bin/behat --ansi
     ```

--- a/tests/behat/behat.yml
+++ b/tests/behat/behat.yml
@@ -2,7 +2,7 @@
 default:
   extensions:
     Behat\MinkExtension\Extension:
-      base_url: http://localhost:8888
+      base_url: http://localhost
       default_session: goutte
       javascript_session: selenium2
       browser_name: "firefox"


### PR DESCRIPTION
spins up a site using drush/make and the installprofile, then runs the behat tests in a headless browser.
fixes #2.
