### PR TITLE
Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,15 +24,15 @@ env:
   - BEHAT_PROFILE='phantomjs'
 
 matrix:
-   fast_finish: true
-   exclude:
-      - php: "5.4"
-      - php: "5.5"
-   include:
-     - php: "5.4"
-       env: BEHAT_PROFILE="phantomjs"
-     - php: "5.5"
-       env: BEHAT_PROFILE="phantomjs"
+  fast_finish: true
+  exclude:
+    - php: 5.4
+    - php: 5.5
+  include:
+    - php: 5.4
+      env: BEHAT_PROFILE="phantomjs"
+    - php: 5.5
+      env: BEHAT_PROFILE="phantomjs"
 
 mysql:
   username: root

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,16 @@ env:
   - BEHAT_PROFILE='osxsafari'
   - BEHAT_PROFILE='phantomjs'
 
+matrix:
+   exclude:
+      - php: "5.4"
+      - php: "5.5"
+   include:
+     - php: "5.4"
+       env: BEHAT_PROFILE="phantomjs"
+     - php: "5.5"
+        env: BEHAT_PROFILE="phantomjs"
+
 mysql:
   username: root
   encoding: utf8

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ env:
   - BEHAT_PROFILE='phantomjs'
 
 matrix:
+   fast_finish: true
    exclude:
       - php: "5.4"
       - php: "5.5"
@@ -31,7 +32,7 @@ matrix:
      - php: "5.4"
        env: BEHAT_PROFILE="phantomjs"
      - php: "5.5"
-        env: BEHAT_PROFILE="phantomjs"
+       env: BEHAT_PROFILE="phantomjs"
 
 mysql:
   username: root

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,13 @@ env:
 matrix:
   fast_finish: true
   exclude:
-    - php: 5.4
-    - php: 5.5
+  - php: 5.4
+  - php: 5.5
   include:
-    - php: 5.4
-      env: BEHAT_PROFILE="phantomjs"
-    - php: 5.5
-      env: BEHAT_PROFILE="phantomjs"
+  - php: 5.4
+    env: BEHAT_PROFILE="phantomjs"
+  - php: 5.5
+    env: BEHAT_PROFILE="phantomjs"
 
 mysql:
   username: root


### PR DESCRIPTION
We don't need full browser tests in all three versions of PHP5.
Run 'em all on PHP 5.3, b/c our main target environment runs on that.
Then just build and run the tests in PhantomJS in PHP 5.4/5.5 to verify that this thing builds/installs and that tests run.
